### PR TITLE
Delay signac-flow template directory permissions update.

### DIFF
--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -145,7 +145,6 @@ curl -sSLO https://github.com/scipy/scipy/releases/download/v1.2.0/scipy-1.2.0.t
     && tar -xzf signac-flow-v0.6.4.tar.gz -C . \
     && export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9" \
     && python3 -m pip install --no-deps --ignore-installed ./signac-flow-v0.6.4 \
-    && chmod o+rX /usr/local/lib/**/dist-packages/flow/templates/* \
     && rm -rf signac-flow-v0.6.4 \
     && rm signac-flow-v0.6.4.tar.gz \
     || exit 1

--- a/template/finalize.jinja
+++ b/template/finalize.jinja
@@ -9,7 +9,8 @@ RUN useradd --create-home --shell /bin/bash glotzerlab-software \
     && chown glotzerlab-software:glotzerlab-software -R /hoomd-examples \
     && chown glotzerlab-software:glotzerlab-software -R /fresnel-examples \
     && chown glotzerlab-software:glotzerlab-software -R /test \
-    && chmod o+rX -R /test
+    && chmod o+rX -R /test \
+    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/*
 
 USER glotzerlab-software:glotzerlab-software
 

--- a/template/glotzerlab-software.jinja
+++ b/template/glotzerlab-software.jinja
@@ -95,7 +95,6 @@
     && tar -xzf signac-flow-{{ SIGNAC_FLOW_VERSION }}.tar.gz -C . \
     && export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}" \
     && python3 -m pip install --no-deps --ignore-installed ./signac-flow-{{ SIGNAC_FLOW_VERSION }} \
-    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/* \
     && rm -rf signac-flow-{{ SIGNAC_FLOW_VERSION }} \
     && rm signac-flow-{{ SIGNAC_FLOW_VERSION }}.tar.gz \
     || exit 1


### PR DESCRIPTION
Move the signac-flow permissions update to the finalize template so
that it is only executed for images.

Fixes issue #3.