### PR TITLE
Python3.8

### DIFF
--- a/template/base.jinja
+++ b/template/base.jinja
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3.8 \
   python3.8-dev \
   python3.8-venv \
+  python3.8-distutils \
   zlib1g-dev \
   ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -32,7 +33,7 @@ ENV PATH=$PATH:/usr/lib/llvm-7/bin
 {% endif %}
 
 # Link python3.8 to python3 in user path
-RUN ln -s "$(which python3.8)" /usr/bin/python3
+RUN rm -f /usr/bin/python3 && ln -s "$(which python3.8)" /usr/bin/python3
 
 # prevent python from loading packages from outside the container
 # default empty pythonpath

--- a/template/base.jinja
+++ b/template/base.jinja
@@ -19,9 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libtbb-dev \
   libsqlite3-dev \
   llvm-7-dev \
-  python3 \
-  python3-dev \
-  python3-venv \
+  python3.8 \
+  python3.8-dev \
+  python3.8-venv \
   zlib1g-dev \
   ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -30,6 +30,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # put clang on the path
 ENV PATH=$PATH:/usr/lib/llvm-7/bin
 {% endif %}
+
+# Link python3.8 to python3 in user path
+RUN ln -s "$(which python3.8)" /usr/bin/python3
 
 # prevent python from loading packages from outside the container
 # default empty pythonpath


### PR DESCRIPTION
Upgrades the software images to use python3.8. Many packages have and will soon drop Python 3.6 support, but we still need to support CUDA 10, so we upgrade the Ubuntu 18 images with python3.8 from bionic-updates.