### PR TITLE
Add UCX on expanse-gpu.

### DIFF
--- a/docker/expanse-gpu/test/job-gpu.sh
+++ b/docker/expanse-gpu/test/job-gpu.sh
@@ -2,12 +2,14 @@
 #SBATCH --job-name="test-gpu"
 #SBATCH --partition=gpu-shared
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --gpus=1
+#SBATCH --ntasks-per-node=2
+#SBATCH --gpus-per-task=1
 #SBATCH -t 0:10:00
 
-module load gpu singularitypro openmpi/4.0.4
+module load gpu singularitypro openmpi/4.0.4-nocuda
 
 rm -f test-results-gpu.out
 
-singularity exec --nv software.sif python3 serial-gpu.py
+mpirun -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+
+mpirun -n 2 singularity exec --nv software.sif python3 mpi-gpu.py

--- a/make_dockerfiles.py
+++ b/make_dockerfiles.py
@@ -108,6 +108,7 @@ if __name__ == '__main__':
           CUDA_VERSION='11.1',
           OPENMPI_VERSION='4.0',
           OPENMPI_PATCHLEVEL='4',
+          UCX_VERSION='1.8.0',
           ENABLE_MPI='on',
           MAKEJOBS=multiprocessing.cpu_count()+2,
           CFLAGS='-march=knl -mmmx -msse -msse2 -msse3 -mssse3 -mcx16 -msahf -mmovbe -maes -mpclmul -mpopcnt -mabm -mfma -mbmi -mbmi2 -mavx -mavx2 -msse4.2 -msse4.1 -mlzcnt -mrtm -mhle -mrdrnd -mf16c -mfsgsbase -mrdseed -mprfchw -madx -mfxsr -mxsave -mxsaveopt -mavx512f -mavx512cd -mclflushopt -mxsavec -mxsaves -mavx512dq -mavx512bw -mavx512vl -mclwb -mpku --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=28160 -mtune=generic',

--- a/template/openmpi.jinja
+++ b/template/openmpi.jinja
@@ -181,6 +181,15 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
 
 {% elif system == 'expanse-gpu' %}
 
+RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
+   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
+   && cd /root/ucx-{{UCX_VERSION}} \
+   && mkdir build && cd build \
+   && ../configure --prefix=/usr  \
+   && make install -j {{ MAKEJOBS }} \
+   && rm -rf /root/ucx-{{UCX_VERSION}} \
+   && rm /ucx-{{UCX_VERSION}}.tar.gz
+
 RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/downloads/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 \
    && tar -xjf openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 -C /root \
    && cd /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
@@ -193,7 +202,7 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
                   --enable-mpi1-compatibility \
                   --without-fca \
                   --without-ofi \
-                  --with-verbs \
+                  --without-verbs \
                   --without-cuda  \
                   --without-mxm \
                   --without-psm \
@@ -210,7 +219,7 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
                   --disable-memchecker \
                   --disable-java \
                   --disable-mpi-java \
-                  --without-ucx \
+                  --with-ucx \
    && make all install \
    && rm -rf /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
    && rm /openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2

--- a/test/mpi-gpu.py
+++ b/test/mpi-gpu.py
@@ -1,0 +1,17 @@
+try:
+    import hoomd
+    dev = hoomd.device.GPU()
+    assert(dev.communicator.num_ranks == 2)
+
+    if (dev.communicator.rank == 0):
+        results = open('test-results-gpu.out', 'a')
+        results.write('** Starting MPI GPU tests **\n')
+        results.write('HOOMD version     : {}\n'.format(hoomd.version.version))
+        results.write('** MPI GPU tests PASSED **\n')
+except:
+    with open('test-results-gpu.out', 'a') as results:
+        results.write('** Starting MPI GPU tests **\n')
+        results.write('** MPI GPU tests FAILED **\n')
+
+    raise
+


### PR DESCRIPTION
Fix errors when running MPI with GPUs on Expanse.

This also improves the MPI communication bandwidth from
```
# OSU MPI Bi-Directional Bandwidth Test v5.4.1
# Size      Bandwidth (MB/s)
1                      12.09
2                      23.25
4                      48.00
8                      97.41
16                    166.63
32                    334.76
64                    532.59
128                   719.90
256                  1211.06
512                  2402.30
1024                 4143.84
2048                 6852.98
4096                 6439.95
8192                 8981.30
16384               11058.01
32768               12179.35
65536               12132.21
131072              12553.19
262144              12603.46
524288              12642.32
1048576             12847.58
2097152             12898.56
4194304             13468.06
```

To:
```
# OSU MPI Bi-Directional Bandwidth Test v5.4.1
# Size      Bandwidth (MB/s)
1                      12.16
2                      20.29
4                      40.57
8                      83.25
16                    160.80
32                    324.90
64                    662.91
128                  1013.62
256                  1969.83
512                  2889.36
1024                 4578.35
2048                 7471.44
4096                 9469.86
8192                13464.64
16384               16429.68
32768               21724.31
65536               24045.07
131072              31608.75
262144              35837.49
524288              40088.84
1048576             27314.69
2097152             21116.29
4194304             21085.67
```

