### PR TITLE
Improve testing and documentation for multi-node jobs.

### DIFF
--- a/doc/clusters/bridges2.rst
+++ b/doc/clusters/bridges2.rst
@@ -47,3 +47,8 @@ MPI parallel GPU jobs (``GPU`` partition)::
 
     module load openmpi/4.0.5-gcc10.2.0
     mpirun singularity exec --bind /ocean --nv $PROJECT/software.sif command arguments
+
+.. important::
+
+    You must use ``mpirun`` to launch parallel jobs. ``srun`` is not compatible with the MPI library
+    installed inside the container.

--- a/doc/clusters/delta.rst
+++ b/doc/clusters/delta.rst
@@ -37,22 +37,22 @@ container:
 
 Serial (or multithreaded) CPU jobs (``cpu`` partition)::
 
-    module load cpu gcc/11.2.0 openmpi/4.1.2
+    module load gcc/11.2.0 openmpi/4.1.2
     mpirun -n 1 singularity exec --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments
 
 Single GPU jobs (``gpuA100x4`` and similar partitions)::
 
-    module load gpu gcc/11.2.0 openmpi/4.1.2
+    module load gcc/11.2.0 openmpi/4.1.2
     mpirun -n 1 singularity exec --nv --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments
 
 MPI parallel CPU jobs (``cpu`` partition with more than 1 core)::
 
-    module load cpu gcc/11.2.0 openmpi/4.1.2
+    module load gcc/11.2.0 openmpi/4.1.2
     mpirun singularity exec --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments
 
 MPI parallel GPU jobs (``gpuA100x4`` and similar partitions with more than 1 GPU)::
 
-    module load gpu gcc/11.2.0 openmpi/4.1.2
+    module load gcc/11.2.0 openmpi/4.1.2
     mpirun singularity exec --nv --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments
 
 .. tip::

--- a/doc/clusters/delta.rst
+++ b/doc/clusters/delta.rst
@@ -14,7 +14,7 @@ The **glotzerlab-software** image and the singularity cache are large, store the
 directory::
 
     $ cd /scratch/<your-account>/$USER/
-    $ export SINGULARITY_CACHEDIR=/scratch/<your-account>/$USER/.singularity
+    $ export APPTAINER_CACHEDIR=/scratch/<your-account>/$USER/.apptainer
 
 .. note::
 
@@ -54,3 +54,11 @@ MPI parallel GPU jobs (``gpuA100x4`` and similar partitions with more than 1 GPU
 
     module load gpu gcc/11.2.0 openmpi/4.1.2
     mpirun singularity exec --nv --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments
+
+.. tip::
+
+    You may use ``srun`` in place of ``mpirun`` on Delta. Set the environment variable
+    ``PMIX_MCA_gds=hash`` before launching processes with ``srun``::
+
+        export PMIX_MCA_gds=hash
+        srun singularity exec --nv --bind /scratch /scratch/<your-account>/$USER/software.sif command arguments

--- a/doc/clusters/expanse.rst
+++ b/doc/clusters/expanse.rst
@@ -83,3 +83,12 @@ MPI parallel GPU jobs (``gpu`` partition, ``gpu-shared`` with more than 1 GPU)::
 .. important::
 
     Use the correct ``module load`` line for the type of node your job will execute on.
+
+.. warning::
+
+    ``mpirun`` will hang when launching jobs one more than one node in the ``gpu`` partition.
+
+.. important::
+
+    You must use ``mpirun`` to launch parallel jobs. ``srun`` is not compatible with the MPI library
+    installed inside the container.

--- a/doc/files.rst
+++ b/doc/files.rst
@@ -1,10 +1,6 @@
 Accessing files
 ===============
 
-Singularity's default behavior is very intuitive when it comes to accessing files on the host. If
-you have problems accessing your files from within the container, read on to understand how the
-process works.
-
 The container's filesystem
 ---------------------------
 
@@ -29,8 +25,8 @@ Bind mounting
 -------------
 
 Specific directories may be *bind mounted* from the host into the container so it can access the
-contents directly. On most systems, Singularity is configured to bind mount your current working
-directory by default::
+contents directly. On most systems, Singularity is configured to bind mount your home directory by
+default::
 
     $ echo "print('hello world')" > script.py
     $ singularity exec software.sif ls
@@ -45,12 +41,13 @@ Even though there are many users on this host system, singularity only sees ``/g
     $ singularity exec software.sif ls /home
     glotzerlab-software  testuser
 
+You can bind mount additional directories with the ``--bind`` command line option.
+
 .. tip::
 
-    Most HPC systems also bind mount their scratch filesytems.
+    Bind the scratch filesystems when launching singularity processes on HPC systems. For example::
 
-If you can't access files that you need to, make sure they are either in the current working
-directory at the time you launch singularity, or they are on the scratch filesystem.
+        singularity exec --nv --bind /scratch
 
 .. seealso::
 

--- a/doc/test.rst
+++ b/doc/test.rst
@@ -21,65 +21,68 @@ Submit the test jobs::
 
     Replace ``sbatch`` with the appropriate queue submission command if necessary.
 
-After the jobs complete, examine the test output::
+After the jobs complete, examine the test output. Here example output::
 
-    $ cat test-results-cpu.out
+    + singularity exec software.sif bash -c set
+    + grep GLOTZERLAB
+    GLOTZERLAB_SOFTWARE_CONFIGURATION=bridges2
+    GLOTZERLAB_SOFTWARE_GIT_BRANCH=trunk
+    GLOTZERLAB_SOFTWARE_GIT_SHA=2327dce1a5cf37351abca48d44a39b93359e55ad
+    GLOTZERLAB_SOFTWARE_TAG=2022.08.19
+    + mpirun -n 1 singularity exec software.sif python3 serial-cpu.py
     ** Starting serial CPU tests **
-    Fresnel version   : 0.6.0
+    Fresnel version   : 0.13.4
     Fresnel device    : <fresnel.Device: All available CPU threads>
-    Freud version     : 0.10.0
-    GSD version       : 1.5.3
-    HOOMD version     : 2.3.4
-    HOOMD flags       : CUDA (8.0) DOUBLE HPMC_MIXED MPI TBB SSE SSE2 SSE3 SSE4_1 SSE4_2 AVX AVX2
-    libgetar version  : 0.6.1
-    pythia version    : 0.2.2
-    plato version     : 1.1.0
-    rowan version     : 1.1.0
-    signac version    : 0.9.3
-    flow version      : 0.6.3
+    Freud version     : 2.11.0
+    garnett version       : 0.7.1
+    GSD version       : 2.6.0
+    HOOMD version     : 3.4.0
+    HOOMD flags       : GPU [CUDA] (11.1) DOUBLE HPMC_MIXED MPI TBB SSE SSE2 SSE3 SSE4_1 SSE4_2 AVX AVX2
+    pythia version    : 0.3.0
+    plato version     : 1.12.0
+    rowan version     : 1.3.0
+    signac version    : 1.7.0
+    flow version      : 0.21.0
 
-    h5py version      : 2.6.0
-    matplotlib version: 1.5.1
-    numpy version     : 1.5.1
-    pandas version    : 1.5.1
-    pillow version    : 5.2.0
-    pyhull version    : 2015.2.0
-    scipy version     : 0.17.0
-    sklearn version   : 0.17
-    pyyaml version    : 3.11
+    h5py version      : 3.7.0
+    matplotlib version: 3.5.3
+    numpy version     : 3.5.3
+    pandas version    : 3.5.3
+    pillow version    : 9.2.0
+    scipy version     : 1.9.0
+    sklearn version   : 1.1.2
+    pyyaml version    : 6.0
     ** Serial CPU tests PASSED **
 
+    + mpirun --npernode 1 singularity exec software.sif python3 mpi-cpu.py
     ** Starting MPI CPU tests **
-    HOOMD version     : 2.3.4
+    HOOMD version     : 3.4.0
     ** MPI CPU tests PASSED **
-    # OSU MPI Bi-Directional Bandwidth Test v5.4.1
+    + mpirun --npernode 1 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw
+    # OSU MPI Bandwidth Test v5.4.1
     # Size      Bandwidth (MB/s)
-    1                       0.02
-    2                       0.03
-    4                       0.07
-    8                       0.18
-    16                      0.27
-    32                      0.59
-    64                      0.93
-    128                   137.51
-    256                   270.04
-    512                   520.99
-    1024                  999.65
-    2048                 1818.69
-    4096                 3349.42
-    8192                 5120.30
-    16384                  37.72
-    32768                  90.25
-    65536                 159.50
-    131072                579.37
-    262144               1547.74
-    524288               3464.45
-    1048576              7672.50
-    2097152              7377.73
-    4194304              7640.81
-
-    $ cat test-results-gpu.out
-    ** Starting serial GPU tests **
-    HOOMD version     : 2.3.4
-    HOOMD flags       : CUDA (8.0) DOUBLE HPMC_MIXED MPI TBB SSE SSE2 SSE3 SSE4_1 SSE4_2 AVX AVX2
-    ** Serial GPU tests PASSED **
+    1                       2.53
+    2                       5.07
+    4                      10.13
+    8                      20.31
+    16                     40.70
+    32                     80.90
+    64                    159.37
+    128                   314.75
+    256                   603.60
+    512                  1186.74
+    1024                 2437.16
+    2048                 4385.84
+    4096                 6576.44
+    8192                10170.07
+    16384               12811.31
+    32768               15895.04
+    65536               17412.40
+    131072              18098.46
+    262144              21474.57
+    524288              22771.60
+    1048576             22894.82
+    2097152             22945.78
+    4194304             23162.50
+    + echo 'Tests complete.'
+    Tests complete.

--- a/docker/bridges2/test/job-cpu.sh
+++ b/docker/bridges2/test/job-cpu.sh
@@ -7,10 +7,15 @@
 #SBATCH -t 0:20:00
 
 module load openmpi/4.0.5-gcc10.2.0
-rm -f test-results-cpu.out
+
+set -x
+
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
 
 mpirun -n 1 singularity exec software.sif python3 serial-cpu.py
 
-mpirun --mca plm_base_verbose 10 singularity exec software.sif python3 mpi-cpu.py
+mpirun --npernode 1 singularity exec software.sif python3 mpi-cpu.py
 
-mpirun --mca plm_base_verbose 10 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw >> test-results-cpu.out
+mpirun --npernode 1 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw
+
+echo "Tests complete."

--- a/docker/bridges2/test/job-gpu.sh
+++ b/docker/bridges2/test/job-gpu.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 #SBATCH --job-name="test-gpu"
-#SBATCH --partition=GPU-shared
-#SBATCH --nodes=1
-#SBATCH --gpus-per-node=1
-#SBATCH -t 0:20:00
+#SBATCH --partition=GPU
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=8
+#SBATCH --ntasks-per-node=1
+#SBATCH -t 0:10:00
 
 module load openmpi/4.0.5-gcc10.2.0
 
-rm -f test-results-gpu.out
+set -x
 
-mpirun -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
+
+mpirun -v -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+
+mpirun -v singularity exec --nv software.sif python3 mpi-gpu.py
+
+mpirun -v singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/delta/test/job-cpu.sh
+++ b/docker/delta/test/job-cpu.sh
@@ -9,10 +9,14 @@
 
 module load gcc/11.2.0 openmpi/4.1.2
 
-rm -f test-results-cpu.out
+set -x
+
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
 
 mpirun -n 1 singularity exec software.sif python3 serial-cpu.py
 
-mpirun singularity exec software.sif python3 mpi-cpu.py
+mpirun --npernode 1 singularity exec software.sif python3 mpi-cpu.py
 
-mpirun singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw >> test-results-cpu.out
+mpirun --npernode 1 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/delta/test/job-gpu.sh
+++ b/docker/delta/test/job-gpu.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 #SBATCH --job-name="test-gpu"
 #SBATCH --partition=gpuA100x4
-#SBATCH --nodes=1
+#SBATCH --nodes=2
 #SBATCH --ntasks-per-node=1
-#SBATCH --gpus=1
+#SBATCH --gpus-per-node=4
 #SBATCH --export=ALL
 #SBATCH -t 0:10:00
 
 module load gcc/11.2.0 openmpi/4.1.2
 
-rm -f test-results-gpu.out
+set -x
 
-mpirun -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
+
+singularity exec --nv software.sif python3 serial-gpu.py
+
+mpirun -v singularity exec --nv software.sif python3 mpi-gpu.py
+
+mpirun -v singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/expanse-gpu/test/job-gpu.sh
+++ b/docker/expanse-gpu/test/job-gpu.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 #SBATCH --job-name="test-gpu"
-#SBATCH --partition=gpu-shared
+#SBATCH --partition=gpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=2
-#SBATCH --gpus-per-task=1
+#SBATCH --gpus=4
 #SBATCH -t 0:10:00
 
 module load gpu singularitypro openmpi/4.0.4-nocuda
 
-rm -f test-results-gpu.out
+set -x
 
-mpirun -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
 
-mpirun -n 2 singularity exec --nv software.sif python3 mpi-gpu.py
+singularity exec --nv software.sif python3 serial-gpu.py
+
+mpirun -v singularity exec --nv software.sif python3 mpi-gpu.py
+
+mpirun -v singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/expanse/test/job-cpu.sh
+++ b/docker/expanse/test/job-cpu.sh
@@ -7,10 +7,14 @@
 
 module load cpu singularitypro gcc/9.2.0 openmpi/4.1.1
 
-rm -f test-results-cpu.out
+set -x
+
+singularity exec software.sif bash -c "set" | grep GLOTZERLAB
 
 singularity exec software.sif python3 serial-cpu.py
 
 mpirun --npernode 1 singularity exec software.sif python3 mpi-cpu.py
 
-mpirun --npernode 1 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw >> test-results-cpu.out
+mpirun --npernode 1 singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/greatlakes/test/job-cpu.sh
+++ b/docker/greatlakes/test/job-cpu.sh
@@ -9,10 +9,12 @@
 
 module load gcc/10.3.0 openmpi/4.1.4 singularity
 
-rm -f test-results-cpu.out
+set -x
 
 mpirun -n 1 singularity exec software.sif python3 serial-cpu.py
 
 mpirun singularity exec software.sif python3 mpi-cpu.py
 
-mpirun singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw >> test-results-cpu.out
+mpirun singularity exec software.sif /opt/osu-micro-benchmarks/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bibw
+
+echo "Tests complete."

--- a/docker/greatlakes/test/job-gpu.sh
+++ b/docker/greatlakes/test/job-gpu.sh
@@ -9,6 +9,8 @@
 
 module load gcc/10.3.0 openmpi/4.1.4 singularity
 
-rm -f test-results-gpu.out
+set -x
 
 mpirun -n 1 singularity exec --nv software.sif python3 serial-gpu.py
+
+echo "Tests complete."

--- a/make_dockerfiles.py
+++ b/make_dockerfiles.py
@@ -25,8 +25,10 @@ if __name__ == '__main__':
     base_template = env.get_template('base.jinja')
     ib_mlx_template = env.get_template('ib-mlx.jinja')
     openmpi_template = env.get_template('openmpi.jinja')
+    pmix_template = env.get_template('pmix.jinja')
     mvapich2_template = env.get_template('mvapich2.jinja')
     summit_template = env.get_template('summit.jinja')
+    ucx_template = env.get_template('ucx.jinja')
     glotzerlab_software_template = env.get_template('glotzerlab-software.jinja')
     finalize_template = env.get_template('finalize.jinja')
     test_template = env.get_template('test.jinja')
@@ -42,7 +44,13 @@ if __name__ == '__main__':
     # for information on obtaining CFLAGS settings for specific machines
     # gcc -'###' -E - -march=native 2>&1 | sed -r '/cc1/!d;s/(")|(^.* - )|( -mno-[^\ ]+)//g'
 
-    write('docker/greatlakes/Dockerfile', [base_template, ib_mlx_template, openmpi_template, glotzerlab_software_template, finalize_template],
+    write('docker/greatlakes/Dockerfile', [base_template,
+                                           ib_mlx_template,
+                                           pmix_template,
+                                           ucx_template,
+                                           openmpi_template,
+                                           glotzerlab_software_template,
+                                           finalize_template],
           FROM='nvidia/cuda:11.6.2-devel-ubuntu20.04',
           system='greatlakes',
           CUDA_VERSION='11.6',
@@ -55,7 +63,13 @@ if __name__ == '__main__':
           CFLAGS='-march=skylake-avx512 -mmmx -msse -msse2 -msse3 -mssse3 -mcx16 -msahf -mmovbe -maes -mpclmul -mpopcnt -mabm -mfma -mbmi -mbmi2 -mavx -mavx2 -msse4.2 -msse4.1 -mlzcnt -mrtm -mhle -mrdrnd -mf16c -mfsgsbase -mrdseed -mprfchw -madx -mfxsr -mxsave -mxsaveopt -mavx512f -mavx512cd -mclflushopt -mxsavec -mxsaves -mavx512dq -mavx512bw -mavx512vl -mclwb -mpku --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=25344 -mtune=skylake-avx512',
           **versions)
 
-    write('docker/delta/Dockerfile', [base_template, ib_mlx_template, openmpi_template, glotzerlab_software_template, finalize_template],
+    write('docker/delta/Dockerfile', [base_template,
+                                      ib_mlx_template,
+                                      pmix_template,
+                                      ucx_template,
+                                      openmpi_template,
+                                      glotzerlab_software_template,
+                                      finalize_template],
           FROM='nvidia/cuda:11.6.2-devel-ubuntu20.04',
           system='delta',
           CUDA_VERSION='11.6',
@@ -78,7 +92,12 @@ if __name__ == '__main__':
           ENABLE_TBB='off',
           **versions)
 
-    write('docker/bridges2/Dockerfile', [base_template, ib_mlx_template, openmpi_template, glotzerlab_software_template, finalize_template],
+    write('docker/bridges2/Dockerfile', [base_template,
+                                         ib_mlx_template,
+                                         ucx_template,
+                                         openmpi_template,
+                                         glotzerlab_software_template,
+                                         finalize_template],
           FROM='nvidia/cuda:11.1.1-devel-ubuntu20.04',
           system='bridges2',
           CUDA_VERSION='11.1',
@@ -90,19 +109,31 @@ if __name__ == '__main__':
           CFLAGS='-march=znver2 -mmmx -msse -msse2 -msse3 -mssse3 -msse4a -mcx16 -msahf -mmovbe -maes -msha -mpclmul -mpopcnt -mabm -mfma -mbmi -mbmi2 -mwbnoinvd -mavx -mavx2 -msse4.2 -msse4.1 -mlzcnt -mrdrnd -mf16c -mfsgsbase -mrdseed -mprfchw -madx -mfxsr -mxsave -mxsaveopt -mclflushopt -mxsavec -mxsaves -mclwb -mmwaitx -mclzero -mrdpid --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=512 -mtune=znver2 -fasynchronous-unwind-tables -fstack-protector-strong -Wformat -Wformat-security -fstack-clash-protection -fcf-protection',
           **versions)
 
-    write('docker/expanse/Dockerfile', [base_template, ib_mlx_template, openmpi_template, glotzerlab_software_template, finalize_template],
+    write('docker/expanse/Dockerfile', [base_template,
+                                        ib_mlx_template,
+                                        pmix_template,
+                                        ucx_template,
+                                        openmpi_template,
+                                        glotzerlab_software_template,
+                                        finalize_template],
           FROM='nvidia/cuda:11.1.1-devel-ubuntu20.04',
           system='expanse',
           CUDA_VERSION='11.1',
           OPENMPI_VERSION='4.1',
           OPENMPI_PATCHLEVEL='1',
+          PMIX_VERSION='4.1.2',
           UCX_VERSION='1.10.1',
           ENABLE_MPI='on',
           MAKEJOBS=multiprocessing.cpu_count()+2,
           CFLAGS='-march=znver2 -mmmx -msse -msse2 -msse3 -mssse3 -msse4a -mcx16 -msahf -mmovbe -maes -msha -mpclmul -mpopcnt -mabm -mfma -mbmi -mbmi2 -mwbnoinvd -mavx -mavx2 -msse4.2 -msse4.1 -mlzcnt -mrdrnd -mf16c -mfsgsbase -mrdseed -mprfchw -madx -mfxsr -mxsave -mxsaveopt -mclflushopt -mxsavec -mxsaves -mclwb -mmwaitx -mclzero -mrdpid --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=512 -mtune=znver2',
           **versions)
 
-    write('docker/expanse-gpu/Dockerfile', [base_template, ib_mlx_template, openmpi_template, glotzerlab_software_template, finalize_template],
+    write('docker/expanse-gpu/Dockerfile', [base_template,
+                                            ib_mlx_template,
+                                            ucx_template,
+                                            openmpi_template,
+                                            glotzerlab_software_template,
+                                            finalize_template],
           FROM='nvidia/cuda:11.1.1-devel-ubuntu20.04',
           system='expanse-gpu',
           CUDA_VERSION='11.1',

--- a/template/openmpi.jinja
+++ b/template/openmpi.jinja
@@ -2,26 +2,6 @@
 
 {% if system == 'greatlakes' %}
 
-# great lakes needs PMIx and UCX
-
-RUN curl -sSLO https://github.com/pmix/pmix/releases/download/v{{ PMIX_VERSION }}/pmix-{{ PMIX_VERSION }}.tar.bz2 \
-   && tar -xjf pmix-{{ PMIX_VERSION }}.tar.bz2 -C /root \
-   && cd /root/pmix-{{ PMIX_VERSION }} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make all install \
-   && rm -rf /root/pmix-{{ PMIX_VERSION }} \
-   && rm /pmix-{{ PMIX_VERSION }}.tar.bz2
-
-RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
-   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
-   && cd /root/ucx-{{UCX_VERSION}} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make install \
-   && rm -rf /root/ucx-{{UCX_VERSION}} \
-   && rm /ucx-{{UCX_VERSION}}.tar.gz
-
 RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/downloads/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 \
    && tar -xjf openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 -C /root \
    && cd /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
@@ -31,24 +11,6 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
    && rm /openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2
 
 {% elif system == 'delta' %}
-
-RUN curl -sSLO https://github.com/pmix/pmix/releases/download/v{{ PMIX_VERSION }}/pmix-{{ PMIX_VERSION }}.tar.bz2 \
-   && tar -xjf pmix-{{ PMIX_VERSION }}.tar.bz2 -C /root \
-   && cd /root/pmix-{{ PMIX_VERSION }} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make all install \
-   && rm -rf /root/pmix-{{ PMIX_VERSION }} \
-   && rm /pmix-{{ PMIX_VERSION }}.tar.bz2
-
-RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
-   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
-   && cd /root/ucx-{{UCX_VERSION}} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make install \
-   && rm -rf /root/ucx-{{UCX_VERSION}} \
-   && rm /ucx-{{UCX_VERSION}}.tar.gz
 
 RUN curl -sSLO https://github.com/ofiwg/libfabric/releases/download/v{{LIBFABRIC_VERSION}}/libfabric-{{LIBFABRIC_VERSION}}.tar.bz2 \
    && tar -xjf libfabric-{{LIBFABRIC_VERSION}}.tar.bz2 -C /root \
@@ -95,15 +57,6 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
 
 # bridges2 needs UCX
 
-RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
-   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
-   && cd /root/ucx-{{UCX_VERSION}} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make install -j {{ MAKEJOBS }} \
-   && rm -rf /root/ucx-{{UCX_VERSION}} \
-   && rm /ucx-{{UCX_VERSION}}.tar.gz
-
 RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/downloads/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 \
    && tar -xjf openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 -C /root \
    && cd /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
@@ -134,17 +87,6 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
 
 {% elif system == 'expanse' %}
 
-# expanse needs UCX
-
-RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
-   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
-   && cd /root/ucx-{{UCX_VERSION}} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make install -j {{ MAKEJOBS }} \
-   && rm -rf /root/ucx-{{UCX_VERSION}} \
-   && rm /ucx-{{UCX_VERSION}}.tar.gz
-
 RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/downloads/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 \
    && tar -xjf openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 -C /root \
    && cd /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
@@ -153,7 +95,7 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
                   --disable-silent-rules \
                   --disable-builtin-atomics \
                   --enable-static \
-                  --without-pmi \
+                  --with-pmix=/usr \
                   --enable-mpi1-compatibility \
                   --without-fca \
                   --without-ofi \
@@ -181,15 +123,6 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
 
 {% elif system == 'expanse-gpu' %}
 
-RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
-   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
-   && cd /root/ucx-{{UCX_VERSION}} \
-   && mkdir build && cd build \
-   && ../configure --prefix=/usr  \
-   && make install -j {{ MAKEJOBS }} \
-   && rm -rf /root/ucx-{{UCX_VERSION}} \
-   && rm /ucx-{{UCX_VERSION}}.tar.gz
-
 RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/downloads/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 \
    && tar -xjf openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }}.tar.bz2 -C /root \
    && cd /root/openmpi-{{ OPENMPI_VERSION }}.{{ OPENMPI_PATCHLEVEL }} \
@@ -198,7 +131,6 @@ RUN curl -sSLO https://www.open-mpi.org/software/ompi/v{{ OPENMPI_VERSION }}/dow
                   --disable-silent-rules \
                   --disable-builtin-atomics \
                   --enable-static \
-                  --without-pmi \
                   --enable-mpi1-compatibility \
                   --without-fca \
                   --without-ofi \

--- a/template/pmix.jinja
+++ b/template/pmix.jinja
@@ -1,0 +1,9 @@
+
+RUN curl -sSLO https://github.com/pmix/pmix/releases/download/v{{ PMIX_VERSION }}/pmix-{{ PMIX_VERSION }}.tar.bz2 \
+   && tar -xjf pmix-{{ PMIX_VERSION }}.tar.bz2 -C /root \
+   && cd /root/pmix-{{ PMIX_VERSION }} \
+   && mkdir build && cd build \
+   && ../configure --prefix=/usr \
+   && make all install \
+   && rm -rf /root/pmix-{{ PMIX_VERSION }} \
+   && rm /pmix-{{ PMIX_VERSION }}.tar.bz2

--- a/template/ucx.jinja
+++ b/template/ucx.jinja
@@ -1,0 +1,9 @@
+
+RUN curl -sSLO https://github.com/openucx/ucx/releases/download/v{{UCX_VERSION}}/ucx-{{UCX_VERSION}}.tar.gz \
+   && tar -xzf ucx-{{UCX_VERSION}}.tar.gz -C /root \
+   && cd /root/ucx-{{UCX_VERSION}} \
+   && mkdir build && cd build \
+   && ../configure --prefix=/usr  \
+   && make install \
+   && rm -rf /root/ucx-{{UCX_VERSION}} \
+   && rm /ucx-{{UCX_VERSION}}.tar.gz

--- a/test/mpi-cpu.py
+++ b/test/mpi-cpu.py
@@ -1,17 +1,18 @@
+import sys
+results = sys.stdout
+
 try:
     import hoomd
     dev = hoomd.device.CPU()
     assert(dev.communicator.num_ranks == 2)
 
     if (dev.communicator.rank == 0):
-        results = open('test-results-cpu.out', 'a')
         results.write('** Starting MPI CPU tests **\n')
         results.write('HOOMD version     : {}\n'.format(hoomd.version.version))
         results.write('** MPI CPU tests PASSED **\n')
 except:
-    with open('test-results-cpu.out', 'a') as results:
-        results.write('** Starting MPI CPU tests **\n')
-        results.write('** MPI CPU tests FAILED **\n')
+    results.write('** Starting MPI CPU tests **\n')
+    results.write('** MPI CPU tests FAILED **\n')
 
     raise
 

--- a/test/mpi-gpu.py
+++ b/test/mpi-gpu.py
@@ -1,17 +1,17 @@
+import sys
+results = sys.stdout
+
 try:
     import hoomd
     dev = hoomd.device.GPU()
     assert(dev.communicator.num_ranks == 2)
 
     if (dev.communicator.rank == 0):
-        results = open('test-results-gpu.out', 'a')
         results.write('** Starting MPI GPU tests **\n')
         results.write('HOOMD version     : {}\n'.format(hoomd.version.version))
         results.write('** MPI GPU tests PASSED **\n')
 except:
-    with open('test-results-gpu.out', 'a') as results:
-        results.write('** Starting MPI GPU tests **\n')
-        results.write('** MPI GPU tests FAILED **\n')
+    results.write('** Starting MPI GPU tests **\n')
+    results.write('** MPI GPU tests FAILED **\n')
 
     raise
-

--- a/test/serial-cpu.py
+++ b/test/serial-cpu.py
@@ -1,4 +1,5 @@
-results = open('test-results-cpu.out', 'a')
+import sys
+results = sys.stdout
 results.write('** Starting serial CPU tests **\n')
 
 try:

--- a/test/serial-gpu.py
+++ b/test/serial-gpu.py
@@ -1,4 +1,5 @@
-results = open('test-results-gpu.out', 'a')
+import sys
+results = sys.stdout
 results.write('** Starting serial GPU tests **\n')
 
 try:


### PR DESCRIPTION
I've gotten reports from multiple users that GPU jobs running on more than one node hang on Expanse and possibly on Bridges-2. This pull request adds multi-GPU jobs to the test environment. 

The Expanse administrators suggested using `srun --mpi=pmi2` to launch jobs. Even with this suggestion, I was unable to fix the problem on Expanse, so I documented the behavior in a warning. Users should use signac-flow to manage many single-node or smaller than single-node GPU jobs on Expanse.

The multi-node GPU job tests on Bridges-2 and Delta are pending.