### PR TITLE
Use previous version of scipy and numpy on summit.

### DIFF
--- a/requirements-source-summit.txt
+++ b/requirements-source-summit.txt
@@ -1,0 +1,7 @@
+Cython==0.29.33
+numpy==1.23.5
+pkgconfig==1.5.5
+pybind11==2.10.3
+pythran==0.12.1
+scikit-build==0.16.6
+scipy==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ hypothesis==6.68.1
 pytest==7.2.1
 miniball==1.1.0
 sympy==1.11.1
-tables==3.8.0
+tables==3.8.0; platform_machine != 'ppc64le'
 coverage==7.1.0
 click==8.1.3
 pytest-cov==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ pyqt5==5.15.9; platform_machine != 'ppc64le'
 pyyaml==6.0
 scikit-learn==1.2.1
 scikit-image==0.19.3; platform_machine != 'ppc64le'
-scipy==1.10.0
 statsmodels==0.13.5; platform_machine != 'ppc64le'
 cupy==11.5.0
 

--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -135,7 +135,7 @@ fi
 # install packages that are build requirements of other packages first
 # lapack is needed for scipy
  export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9"\
-    && python3 -m pip install -r requirements-source.txt \
+    && python3 -m pip install -r requirements-source-summit.txt \
     || exit 1
 
 # unlike with Docker builds, use the pip cache on summit to reduce time when rerunning the install script

--- a/template/glotzerlab-software.jinja
+++ b/template/glotzerlab-software.jinja
@@ -20,7 +20,7 @@
 # install packages that are build requirements of other packages first
 # lapack is needed for scipy
 {{ RUN }} export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}"\
-    && python3 -m pip install -r requirements-source.txt \
+    && python3 -m pip install -r requirements-source-summit.txt \
     || exit 1
 
 # unlike with Docker builds, use the pip cache on summit to reduce time when rerunning the install script


### PR DESCRIPTION
The latest versions of numpy and scipy fail to build on summit.