### PR TITLE
Prune existing docker images before building.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Clear existing images
+        run: docker system prune -a -f
       - name: Build image
         run: ./build.sh -r glotzerlab ${{ matrix.configuration }}
       - name: Push image


### PR DESCRIPTION
Attempt to work around an issue I found where `docker push` was pushing an *existing* glotzerlab/software:nompi image on the host instead of the newly built one.