### PR TITLE
Add support/install scripts for frontier

### DIFF
--- a/doc/cluster.rst
+++ b/doc/cluster.rst
@@ -16,3 +16,4 @@ community <community>` for suggestions.
     clusters/expanse
     clusters/greatlakes
     clusters/summit
+    clusters/frontier

--- a/doc/cluster.rst
+++ b/doc/cluster.rst
@@ -14,6 +14,6 @@ community <community>` for suggestions.
     clusters/crusher
     clusters/delta
     clusters/expanse
+    clusters/frontier
     clusters/greatlakes
     clusters/summit
-    clusters/frontier

--- a/doc/clusters/frontier.rst
+++ b/doc/clusters/frontier.rst
@@ -1,0 +1,42 @@
+Crusher (OLCF)
+--------------
+
+`frontier <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html>`_ is a system
+at ORNL.
+
+Frontier does not support container execution at this time. **glotzerlab-software** instead provides
+a build script and a module environment to create an equivalent software stack.
+
+First, clone the **glotzerlab-software** repository::
+
+    $ git clone https://github.com/glotzerlab/software
+    $ cd software
+
+If you already have a clone, update it::
+
+    $ cd software
+    $ git pull origin trunk
+
+Per OLCF policies, you should install your software in NFS under ``/ccs/proj/``. For example,
+set the installation root directory to ``/ccs/proj/{your-project}/software/${USER}``.
+
+Build the software environment and install it into the root::
+
+    $ script/frontier/install.sh /ccs/proj/{your-project}/software/${USER}
+    ... compiling software will take several minutes ...
+
+Activate the environment with::
+
+    $ source /ccs/proj/{your-project}/software/${USER}/environment.sh
+
+The environment is a `python3 venv <https://docs.python.org/3/library/venv.html>`_. You may extend
+it with additional python packages using ``python3 -m pip install``::
+
+    $ source /ccs/proj/{your-project}/software/${USER}/environment.sh
+    $ python3 -m pip install package
+
+Use the following commands in your job scripts or interactively to execute software inside the
+container::
+
+    source /ccs/proj/{your-project}/software/${USER}/environment.sh
+    srun {srun options} command arguments

--- a/doc/clusters/frontier.rst
+++ b/doc/clusters/frontier.rst
@@ -1,4 +1,4 @@
-Crusher (OLCF)
+Frontier (OLCF)
 --------------
 
 `frontier <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html>`_ is a system

--- a/doc/clusters/frontier.rst
+++ b/doc/clusters/frontier.rst
@@ -1,5 +1,5 @@
 Frontier (OLCF)
---------------
+---------------
 
 `frontier <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html>`_ is a system
 at ORNL.

--- a/make_dockerfiles.py
+++ b/make_dockerfiles.py
@@ -25,6 +25,8 @@ if __name__ == '__main__':
     base_template = env.get_template('base.jinja')
     crusher_template = env.get_template('crusher.jinja')
     crusher_finalize_template = env.get_template('crusher_finalize.jinja')
+    frontier_template = env.get_template('frontier.jinja')
+    frontier_finalize_template = env.get_template('frontier_finalize.jinja')
     ib_mlx_template = env.get_template('ib-mlx.jinja')
     openmpi_template = env.get_template('openmpi.jinja')
     pmix_template = env.get_template('pmix.jinja')
@@ -99,6 +101,17 @@ if __name__ == '__main__':
           CFLAGS='-march=native',
           output='script',
           system='crusher',
+          ENABLE_MPI='on',
+          ENABLE_TBB='off',
+          ENABLE_LLVM='off',
+          HOOMD_GPU_PLATFORM='HIP',
+          **versions)
+
+    write('script/frontier/install.sh', [frontier_template, glotzerlab_software_template, frontier_finalize_template],
+          MAKEJOBS=32,
+          CFLAGS='-march=native',
+          output='script',
+          system='frontier',
           ENABLE_MPI='on',
           ENABLE_TBB='off',
           ENABLE_LLVM='off',

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jupyterlab==3.6.3; platform_machine != 'ppc64le'
 matplotlib==3.7.1; platform_machine != 'ppc64le'
 notebook==6.5.4; platform_machine != 'ppc64le'
 opencv-python==4.7.0.72; platform_machine != 'ppc64le'
-pandas==2.0.0
+pandas==1.5.3
 Pillow==9.5.0
 pyqt5==5.15.9; platform_machine != 'ppc64le'
 pyyaml==6.0

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/bash
+
+set -u
+set -e
+
+usage="$(basename "$0") root -- Build software and install in root."
+
+if [[ $# -lt 1 || $# -gt 1  || $1 == "-h" ]]
+then
+    echo "$usage"
+    exit 0
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT=$1
+module reset
+module load cray-python/3.9.13.1
+python3 -m venv $ROOT
+
+cat >$ROOT/environment.sh << EOL
+module reset
+module load PrgEnv-gnu
+module load cmake/3.23.2
+module load git/2.36.1
+module load rocm/5.4.3
+module load cray-python/3.9.13.1
+module load hdf5/1.14.0
+module load ninja/1.10.2
+module load tmux/3.2a
+
+# The cray-mpich module does not provide this, it is needed to build mpi4py from source.
+export MPICC=\$CRAY_MPICH_DIR/bin/mpicc
+
+export LD_LIBRARY_PATH=$ROOT/lib:\$LD_LIBRARY_PATH
+export PATH=$ROOT/bin:\$PATH
+export CPATH=$ROOT/include
+export LIBRARY_PATH=$ROOT/lib
+export VIRTUAL_ENV=$ROOT
+export CMAKE_PREFIX_PATH=$ROOT
+export CC=\$GCC_PATH/bin/gcc
+export CXX=\$GCC_PATH/bin/g++
+
+# Settings to build cupy for rocm: https://docs.cupy.dev/en/stable/install.html
+export CUPY_INSTALL_USE_HIP=1
+export ROCM_HOME=\$OLCF_ROCM_ROOT
+export HCC_AMDGPU_TARGET=gfx90a
+EOL
+
+source $ROOT/environment.sh
+
+set -x
+
+BUILDDIR=`mktemp -d`
+mkdir -p $BUILDDIR
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$BUILDDIR"
+  echo "Deleted temp working directory $BUILDDIR"
+}
+
+trap cleanup EXIT
+cd $BUILDDIR
+
+cp -a $DIR/../../*.txt $BUILDDIR
+cd $BUILDDIR
+
+set -x
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -r requirements-mpi.txt
+
+# TBB
+if [ ! -f $ROOT/lib64/libtbb.so ]
+then
+curl -sSLO https://github.com/oneapi-src/oneTBB/archive/v2021.9.0.tar.gz \
+    && tar -xzf v2021.9.0.tar.gz -C . \
+    && cd oneTBB-2021.9.0 \
+    && cmake -S . -B build -DTBB_TEST=off -DTBB_STRICT=off -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ROOT \
+    && cmake --build build -j 32  \
+    && cmake --install build \
+    && cd .. \
+    && rm -rf oneTBB-2021.9.0 \
+    && rm v2021.9.0.tar.gz \
+    || exit 1
+fi
+
+# Embree
+if [ ! -f $ROOT/lib64/libembree3.so ]
+then
+curl -sSL https://github.com/embree/embree/archive/v4.0.1/embree-4.0.1.tar.gz | tar -xzC $BUILDDIR \
+    && cd $BUILDDIR/embree-4.0.1 \
+    && mkdir build && cd build \
+    && cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DCMAKE_INSTALL_LIBDIR=lib64/ -DCMAKE_BUILD_TYPE=Release -DEMBREE_TUTORIALS=OFF -DEMBREE_MAX_ISA="AVX2" -DEMBREE_ISPC_SUPPORT=OFF \
+    && make install -j 32 \
+    && cd $BUILDDIR/ && rm -rf embree-*
+fi
+
+# install pybind11 headers
+if [ ! -f $ROOT/include/pybind11/pybind11.h ]
+then
+curl -SL https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz | tar -xzC $BUILDDIR && \
+    cd pybind11-2.10.4 && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DPYBIND11_TEST=off && \
+    make install && \
+    cd $BUILDDIR && rm -rf pybind11-*
+fi
+
+# install cereal headers
+if [ ! -f $ROOT/include/cereal/cereal.hpp ]
+then
+curl -SL https://github.com/USCiLab/cereal/archive/v1.3.2.tar.gz | tar -xzC $BUILDDIR && \
+    cd cereal-1.3.2 && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DJUST_INSTALL_CEREAL=on && \
+    make install && \
+    cd $BUILDDIR && rm -rf cereal-*
+fi
+
+# install eigen headers
+if [ ! -f $ROOT/include/eigen3/Eigen/Eigen ]
+then
+curl -SL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz | tar -xzC $BUILDDIR && \
+    cd eigen-3.4.0 && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DBUILD_TESTING=off, -DEIGEN_TEST_NOQT=on && \
+    make install && \
+    cd $BUILDDIR && rm -rf eigen-*
+fi
+
+
+
+
+
+# Install packages that are build requirements of other packages first.
+# lapack is needed for scipy.
+# Use the pip cache in script builds to reduce time when rerunning the install script.
+
+
+ export CFLAGS="-march=native" CXXFLAGS="-march=native"\
+    && python3 -m pip install -r requirements-source.txt \
+    || exit 1
+
+
+ export CFLAGS="-march=native" CXXFLAGS="-march=native" \
+    && python3 -m pip install --no-build-isolation -r requirements.txt \
+    || exit 1
+
+
+
+
+
+
+if [ ! -n "$(ls -d $ROOT/lib/python*/site-packages/fresnel)" ]
+then
+
+ git clone --recursive --branch v0.13.5 --depth 1 https://github.com/glotzerlab/fresnel \
+    && cd fresnel \
+    && mkdir -p build \
+    && cd build \
+    && export CFLAGS="-march=native" CXXFLAGS="-march=native" \
+    && cmake ../ -DENABLE_EMBREE=on -DENABLE_OPTIX=off -Dembree_DIR=/opt/embree-4.0.1.x86_64.linux -DCMAKE_INSTALL_PREFIX=`python3 -c "import site; print(site.getsitepackages()[0])"` \
+    && make install -j32 \
+    && cd ../../ \
+    && rm -rf fresnel \
+    || exit 1
+
+
+fi
+
+
+
+
+
+
+if [ ! -n "$(ls -d $ROOT/lib/python*/site-packages/hoomd)" ]
+then
+
+ git clone --recursive --branch v3.11.0 --depth 1 https://github.com/glotzerlab/hoomd-blue hoomd \
+    && cd hoomd \
+    && mkdir -p build \
+    && cd build \
+    && export CFLAGS="-march=native" CXXFLAGS="-march=native" \
+    && cmake ../ -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_GPU=on -DENABLE_MPI=on -DENABLE_TBB=off -DENABLE_LLVM=off -DBUILD_TESTING=off -DENABLE_MPI_CUDA=off -DHOOMD_GPU_PLATFORM=HIP \
+    && make install -j32 \
+    && cd ../../ \
+    && rm -rf hoomd \
+    || exit 1
+
+
+fi
+# cupy does not support the cuda array interface on crusher
+pip uninstall -y cupy
+
+# pip uninstall does not remote the cupy directory, so `import cupy` still works:
+rm -rf $ROOT/lib/python*/site-packages/cupy

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -1,0 +1,129 @@
+#!/usr/bin/bash
+
+set -u
+set -e
+
+usage="$(basename "$0") root -- Build software and install in root."
+
+if [[ $# -lt 1 || $# -gt 1  || $1 == "-h" ]]
+then
+    echo "$usage"
+    exit 0
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT=$1
+module reset
+module load cray-python/3.9.13.1
+python3 -m venv $ROOT
+
+cat >$ROOT/environment.sh << EOL
+module reset
+module load PrgEnv-gnu
+module load cmake/3.23.2
+module load git/2.36.1
+module load rocm/5.4.3
+module load cray-python/3.9.13.1
+module load hdf5/1.14.0
+module load ninja/1.10.2
+module load tmux/3.2a
+
+# The cray-mpich module does not provide this, it is needed to build mpi4py from source.
+export MPICC=\$CRAY_MPICH_DIR/bin/mpicc
+
+export LD_LIBRARY_PATH=$ROOT/lib:\$LD_LIBRARY_PATH
+export PATH=$ROOT/bin:\$PATH
+export CPATH=$ROOT/include
+export LIBRARY_PATH=$ROOT/lib
+export VIRTUAL_ENV=$ROOT
+export CMAKE_PREFIX_PATH=$ROOT
+export CC=\$GCC_PATH/bin/gcc
+export CXX=\$GCC_PATH/bin/g++
+
+# Settings to build cupy for rocm: https://docs.cupy.dev/en/stable/install.html
+export CUPY_INSTALL_USE_HIP=1
+export ROCM_HOME=\$OLCF_ROCM_ROOT
+export HCC_AMDGPU_TARGET=gfx90a
+EOL
+
+source $ROOT/environment.sh
+
+set -x
+
+BUILDDIR=`mktemp -d`
+mkdir -p $BUILDDIR
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$BUILDDIR"
+  echo "Deleted temp working directory $BUILDDIR"
+}
+
+trap cleanup EXIT
+cd $BUILDDIR
+
+cp -a $DIR/../../*.txt $BUILDDIR
+cd $BUILDDIR
+
+set -x
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -r requirements-mpi.txt
+
+# TBB
+if [ ! -f $ROOT/lib64/libtbb.so ]
+then
+curl -sSLO https://github.com/oneapi-src/oneTBB/archive/v{{ TBB_VERSION }}.tar.gz \
+    && tar -xzf v{{ TBB_VERSION }}.tar.gz -C . \
+    && cd oneTBB-{{ TBB_VERSION }} \
+    && cmake -S . -B build -DTBB_TEST=off -DTBB_STRICT=off -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ROOT \
+    && cmake --build build -j {{ MAKEJOBS }}  \
+    && cmake --install build \
+    && cd .. \
+    && rm -rf oneTBB-{{ TBB_VERSION }} \
+    && rm v{{ TBB_VERSION }}.tar.gz \
+    || exit 1
+fi
+
+# Embree
+if [ ! -f $ROOT/lib64/libembree3.so ]
+then
+curl -sSL https://github.com/embree/embree/archive/v{{ EMBREE_VERSION }}/embree-{{ EMBREE_VERSION }}.tar.gz | tar -xzC $BUILDDIR \
+    && cd $BUILDDIR/embree-{{ EMBREE_VERSION }} \
+    && mkdir build && cd build \
+    && cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DCMAKE_INSTALL_LIBDIR=lib64/ -DCMAKE_BUILD_TYPE=Release -DEMBREE_TUTORIALS=OFF -DEMBREE_MAX_ISA="AVX2" -DEMBREE_ISPC_SUPPORT=OFF \
+    && make install -j {{ MAKEJOBS }} \
+    && cd $BUILDDIR/ && rm -rf embree-*
+fi
+
+# install pybind11 headers
+if [ ! -f $ROOT/include/pybind11/pybind11.h ]
+then
+curl -SL https://github.com/pybind/pybind11/archive/v{{PYBIND11_VERSION}}.tar.gz | tar -xzC $BUILDDIR && \
+    cd pybind11-{{PYBIND11_VERSION}} && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DPYBIND11_TEST=off && \
+    make install && \
+    cd $BUILDDIR && rm -rf pybind11-*
+fi
+
+# install cereal headers
+if [ ! -f $ROOT/include/cereal/cereal.hpp ]
+then
+curl -SL https://github.com/USCiLab/cereal/archive/v{{CEREAL_VERSION}}.tar.gz | tar -xzC $BUILDDIR && \
+    cd cereal-{{CEREAL_VERSION}} && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DJUST_INSTALL_CEREAL=on && \
+    make install && \
+    cd $BUILDDIR && rm -rf cereal-*
+fi
+
+# install eigen headers
+if [ ! -f $ROOT/include/eigen3/Eigen/Eigen ]
+then
+curl -SL https://gitlab.com/libeigen/eigen/-/archive/{{EIGEN_VERSION}}/eigen-{{EIGEN_VERSION}}.tar.gz | tar -xzC $BUILDDIR && \
+    cd eigen-{{EIGEN_VERSION}} && \
+    mkdir build && cd build && \
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$ROOT -DBUILD_TESTING=off, -DEIGEN_TEST_NOQT=on && \
+    make install && \
+    cd $BUILDDIR && rm -rf eigen-*
+fi

--- a/template/frontier_finalize.jinja
+++ b/template/frontier_finalize.jinja
@@ -1,0 +1,5 @@
+# cupy does not support the cuda array interface on crusher
+pip uninstall -y cupy
+
+# pip uninstall does not remote the cupy directory, so `import cupy` still works:
+rm -rf $ROOT/lib/python*/site-packages/cupy


### PR DESCRIPTION
Frontier at OLCF install scripts.
Pandas version was also changed (downgraded) due to incompatibilities.
NOTE: When install script was run Frontier decided to use gcc version 8 even though version 12 was available and loaded.