### PR TITLE
[ci skip] Note that users must pull expanse image on another system.

### DIFF
--- a/doc/clusters/expanse.rst
+++ b/doc/clusters/expanse.rst
@@ -10,21 +10,14 @@ the ACCESS_ program.
 Downloading
 ***********
 
-Singularity requires more memory than Expanse provides on the login node. Launch an interactive
-job with sufficient memory and perform the image pull steps on a compute node::
+For unknown reasons, ``singularity pull`` generates corrupt images when run on Expanse. You need
+to use another Linux system to pull the ``expanse`` or ``expanse-gpu`` image, then copy that image
+to Expanse.
 
-    $ srun --partition=shared --pty --nodes=1 --ntasks-per-node=1 --mem=8G --time=02:00:00 --wait=0 --export=ALL --account=<your-account> /bin/bash
+.. note::
 
-The **glotzerlab-software** image and the singularity cache are large, normally you would store them
-in your scratch directory. **However**, the lustre filesystem on Expanse causes problems with
-``singularity pull``. Pull the images in your home directory and move them to scratch. You will need
-to periodically clear the cache to prevent it from filling your quota::
-
-    $ rm -rf $HOME/.singularity
-
-Unset the cache directory if you set it based on previous instructions in this documentation::
-
-    $ unset SINGULARITY_CACHEDIR
+    The corrupt image causes ``/usr/<some_file>.so: file too short`` error messages when you
+    attempt to use software in the container.
 
 CPU
 +++
@@ -32,7 +25,8 @@ CPU
 Download the image with support for Expanse's CPU nodes::
 
     $ singularity pull software.sif docker://glotzerlab/software:expanse
-    $ mv software.sif /expanse/lustre/scratch/$USER/temp_project/
+
+Then copy ``software.sif`` to ``/expanse/lustre/scratch/$USER/temp_project/`` on Expanse.
 
 GPU
 +++
@@ -40,7 +34,8 @@ GPU
 Download the image with support for Expanse's GPU nodes::
 
     $ singularity pull software.sif docker://glotzerlab/software:expanse-gpu
-    $ mv software.sif /expanse/lustre/scratch/$USER/temp_project/
+
+Then copy ``software.sif`` to ``/expanse/lustre/scratch/$USER/temp_project/`` on Expanse.
 
 .. important::
 


### PR DESCRIPTION
Previously, the corrupt images resulted only when pulling on the lustre filesystem. Today, I found the same error for the home directory. `/tmp` is not large enough to pull the image on the compute nodes. The only option left for users is to pull on another Linux system and copy the image to Expanse.