### PR TITLE
Unload darshan-runtime in Frontier script

### DIFF
--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -27,7 +27,7 @@ module load cray-python/3.9.13.1
 module load hdf5/1.14.0
 module load ninja/1.10.2
 module load tmux/3.2a
-module unload darshan-runtime/3.4.0
+module unload darshan-runtime
 
 # The cray-mpich module does not provide this, it is needed to build mpi4py from source.
 export MPICC=\$CRAY_MPICH_DIR/bin/mpicc

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -27,6 +27,7 @@ module load cray-python/3.9.13.1
 module load hdf5/1.14.0
 module load ninja/1.10.2
 module load tmux/3.2a
+module unload darshan-runtime/3.4.0
 
 # The cray-mpich module does not provide this, it is needed to build mpi4py from source.
 export MPICC=\$CRAY_MPICH_DIR/bin/mpicc

--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -28,6 +28,7 @@ module load cmake
 module load git
 module load netlib-lapack/3.9.1
 module load hdf5/1.10.7
+module unload darshan-runtime
 
 export LD_LIBRARY_PATH=$ROOT/lib:\$LD_LIBRARY_PATH
 export PATH=$ROOT/bin:\$PATH

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -27,6 +27,7 @@ module load cray-python/3.9.13.1
 module load hdf5/1.14.0
 module load ninja/1.10.2
 module load tmux/3.2a
+module unload darshan-runtime
 
 # The cray-mpich module does not provide this, it is needed to build mpi4py from source.
 export MPICC=\$CRAY_MPICH_DIR/bin/mpicc

--- a/template/summit.jinja
+++ b/template/summit.jinja
@@ -28,6 +28,7 @@ module load cmake
 module load git
 module load netlib-lapack/3.9.1
 module load hdf5/1.10.7
+module unload darshan-runtime
 
 export LD_LIBRARY_PATH=$ROOT/lib:\$LD_LIBRARY_PATH
 export PATH=$ROOT/bin:\$PATH


### PR DESCRIPTION
Removes the darshan-runtime from the module list in Frontier's environment.sh file.
