### PR TITLE
Fix OLCF build scripts.

### DIFF
--- a/make_dockerfiles.py
+++ b/make_dockerfiles.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     finalize_template = env.get_template('finalize.jinja')
     test_template = env.get_template('test.jinja')
 
-    write('docker/nompi/Dockerfile', [base_template, glotzerlab_software_template, finalize_template, test_template],
+    write('docker/nompi/Dockerfile', [base_template, glotzerlab_software_template, test_template, finalize_template],
           FROM='nvidia/cuda:11.1.1-devel-ubuntu20.04',
           ENABLE_MPI='off',
           MAKEJOBS=multiprocessing.cpu_count()+2,

--- a/requirements-source-summit.txt
+++ b/requirements-source-summit.txt
@@ -2,7 +2,8 @@ Cython==0.29.33
 numpy==1.22.4
 pkgconfig==1.5.5
 pybind11==2.10.3
-pythran==0.12.1
+pythran==0.12.2
 scikit-build==0.16.6
+meson-python==0.9.0
 scipy==1.9.3
-versioneer==0.28
+versioneer[toml]==0.28

--- a/script/crusher/install.sh
+++ b/script/crusher/install.sh
@@ -143,6 +143,7 @@ fi
 
  export CFLAGS="-march=native" CXXFLAGS="-march=native" \
     && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt \
+    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/* \
     || exit 1
 
 

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -12,7 +12,8 @@ then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$1
+ROOT=$(realpath $1)
+echo "Installing glotzerlab-software to $ROOT"
 module purge
 module load PrgEnv-gnu
 module load cray-python/3.9.13.1

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -13,12 +13,13 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT=$1
-module reset
+module purge
+module load PrgEnv-gnu
 module load cray-python/3.9.13.1
 python3 -m venv $ROOT
 
 cat >$ROOT/environment.sh << EOL
-module reset
+module purge
 module load PrgEnv-gnu
 module load cmake/3.23.2
 module load git/2.36.1

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -146,6 +146,7 @@ fi
 
  export CFLAGS="-march=native" CXXFLAGS="-march=native" \
     && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt \
+    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/* \
     || exit 1
 
 

--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -12,7 +12,8 @@ then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$1
+ROOT=$(realpath $1)
+echo "Installing glotzerlab-software to $ROOT"
 module reset
 module load gcc/7.5.0
 module load python/3.8.10

--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -59,7 +59,8 @@ cp -a $DIR/../../*.txt $BUILDDIR
 cd $BUILDDIR
 
 set -x
-python3 -m pip install --upgrade pip setuptools wheel
+# setuptools <60 needed to build scipy 1.9.3 from source
+python3 -m pip install --upgrade pip setuptools==59.8.0 wheel
 python3 -m pip install -r requirements-mpi.txt
 
 # TBB
@@ -137,9 +138,13 @@ fi
 # Use the pip cache in script builds to reduce time when rerunning the install script.
 
 
- export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9"\
-    && python3 -m pip install -r requirements-source-summit.txt \
-    || exit 1
+ export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9"
+while read package; do
+  python3 -m pip install --no-build-isolation $package || exit 1
+done <requirements-source-summit.txt
+
+ # modern setuptools needed for gsd and other packages\
+ python3 -m pip install --upgrade setuptools
 
 
  export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9" \

--- a/script/summit/install.sh
+++ b/script/summit/install.sh
@@ -150,6 +150,7 @@ done <requirements-source-summit.txt
 
  export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9" \
     && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt \
+    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/* \
     || exit 1
 
 

--- a/template/base.jinja
+++ b/template/base.jinja
@@ -87,3 +87,7 @@ COPY requirements*.txt /
 # Fix library search paths
 RUN echo "/usr/local/cuda-{{ CUDA_VERSION }}/compat" >> /etc/ld.so.conf.d/999-cuda-glotzerlab.conf
 RUN ldconfig
+
+# setup self test
+RUN mkdir /test
+COPY test/* /test/

--- a/template/finalize.jinja
+++ b/template/finalize.jinja
@@ -1,3 +1,5 @@
+
+
 # configure unprivileged user
 RUN useradd --create-home --shell /bin/bash glotzerlab-software \
     && chown glotzerlab-software:glotzerlab-software -R /test \

--- a/template/finalize.jinja
+++ b/template/finalize.jinja
@@ -1,13 +1,6 @@
-
-
-# setup self test
-RUN mkdir /test
-COPY test/* /test/
-
 # configure unprivileged user
 RUN useradd --create-home --shell /bin/bash glotzerlab-software \
     && chown glotzerlab-software:glotzerlab-software -R /test \
-    && chmod o+rX -R /test \
-    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/*
+    && chmod o+rX -R /test
 
 USER glotzerlab-software:glotzerlab-software

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -12,7 +12,8 @@ then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$1
+ROOT=$(realpath $1)
+echo "Installing glotzerlab-software to $ROOT"
 module purge
 module load PrgEnv-gnu
 module load cray-python/3.9.13.1

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -13,12 +13,13 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT=$1
-module reset
+module purge
+module load PrgEnv-gnu
 module load cray-python/3.9.13.1
 python3 -m venv $ROOT
 
 cat >$ROOT/environment.sh << EOL
-module reset
+module purge
 module load PrgEnv-gnu
 module load cmake/3.23.2
 module load git/2.36.1

--- a/template/glotzerlab-software.jinja
+++ b/template/glotzerlab-software.jinja
@@ -21,9 +21,13 @@
 # Use the pip cache in script builds to reduce time when rerunning the install script.
 
 {% if system == 'summit' %}
-{{ RUN }} export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}"\
-    && python3 -m pip install -r requirements-source-summit.txt \
-    || exit 1
+{{ RUN }} export CFLAGS="-mcpu=power9 -mtune=power9" CXXFLAGS="-mcpu=power9 -mtune=power9"
+while read package; do
+  python3 -m pip install --no-build-isolation $package || exit 1
+done <requirements-source-summit.txt
+
+ # modern setuptools needed for gsd and other packages\
+ python3 -m pip install --upgrade setuptools
 {% else %}
 {{ RUN }} export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}"\
     && python3 -m pip install -r requirements-source.txt \

--- a/template/glotzerlab-software.jinja
+++ b/template/glotzerlab-software.jinja
@@ -36,6 +36,7 @@ done <requirements-source-summit.txt
 
 {{ RUN }} export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}" \
     && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt \
+    && chmod o+rX `python3 -c "import site; print(site.getsitepackages()[0])"`/flow/templates/* \
     || exit 1
 
 {% if system != 'crusher' and system != 'frontier' %}

--- a/template/summit.jinja
+++ b/template/summit.jinja
@@ -12,7 +12,8 @@ then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$1
+ROOT=$(realpath $1)
+echo "Installing glotzerlab-software to $ROOT"
 module reset
 module load gcc/7.5.0
 module load python/3.8.10

--- a/template/summit.jinja
+++ b/template/summit.jinja
@@ -59,7 +59,8 @@ cp -a $DIR/../../*.txt $BUILDDIR
 cd $BUILDDIR
 
 set -x
-python3 -m pip install --upgrade pip setuptools wheel
+# setuptools <60 needed to build scipy 1.9.3 from source
+python3 -m pip install --upgrade pip setuptools==59.8.0 wheel
 python3 -m pip install -r requirements-mpi.txt
 
 # TBB

--- a/template/test.jinja
+++ b/template/test.jinja
@@ -1,5 +1,9 @@
 
 
+# setup self test
+RUN mkdir /test
+COPY test/* /test/
+
 RUN cd /test && \
     python3 serial-cpu.py
 

--- a/template/test.jinja
+++ b/template/test.jinja
@@ -1,9 +1,5 @@
 
 
-# setup self test
-RUN mkdir /test
-COPY test/* /test/
-
 RUN cd /test && \
     python3 serial-cpu.py
 


### PR DESCRIPTION
* Adjust method of installing old packages on Summit so that they build in the current environment.
* Work around `module` failing to initialize in zsh on Frontier.