### PR TITLE
Restore cupy install in Docker containers.

### DIFF
--- a/template/glotzerlab-software.jinja
+++ b/template/glotzerlab-software.jinja
@@ -12,7 +12,7 @@
 
 # build select packages from source with machine specific flags
 {{ RUN }} export CFLAGS="{{CFLAGS}}" CXXFLAGS="{{CFLAGS}}" \
-    && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt \
+    && python3 -m pip install --no-build-isolation --no-binary freud-analysis,gsd -r requirements.txt -r requirements-cupy.txt \
     && python3 -m pip cache purge
 
 {% else %}


### PR DESCRIPTION
A previous pull request accidentally removed cupy from the Docker container builds.