### PR TITLE
Frontier: Increase PMPI_Init timeout, allow NVME and use Python 3.10.

### DIFF
--- a/doc/clusters/frontier.rst
+++ b/doc/clusters/frontier.rst
@@ -51,6 +51,6 @@ into NVME and execute software from there::
     srun --ntasks-per-node 1 mkdir ${GLOTZERLAB_SOFTWARE_ROOT}
     srun --ntasks-per-node 1 tar --directory ${GLOTZERLAB_SOFTWARE_ROOT} -xpf \
       ${MEMBERWORK}/{your-project}/software.tar
-
     source ${GLOTZERLAB_SOFTWARE_ROOT}/variables.sh
+
     srun {srun options} command arguments

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -40,6 +40,7 @@ export CPATH=\$GLOTZERLAB_SOFTWARE_ROOT/include
 export LIBRARY_PATH=\$GLOTZERLAB_SOFTWARE_ROOT/lib
 export VIRTUAL_ENV=\$GLOTZERLAB_SOFTWARE_ROOT
 export CMAKE_PREFIX_PATH=\$GLOTZERLAB_SOFTWARE_ROOT
+export PYTHONPATH=\$(\${GLOTZERLAB_SOFTWARE_ROOT}/bin/python -c 'import site; print(site.getsitepackages()[0])')
 export CC=\$GCC_PATH/bin/gcc
 export CXX=\$GCC_PATH/bin/g++
 
@@ -71,7 +72,7 @@ fi
 
 DEST=\$(realpath \$1)
 
-tar --directory $ROOT --exclude software.tar -cvf \$DEST .
+tar --directory $ROOT --exclude software.tar -cf \$DEST .
 EOL
 chmod ug+x $ROOT/generate-tar-cache.sh
 

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -71,7 +71,7 @@ fi
 
 DEST=\$(realpath \$1)
 
-tar --directory $ROOT --exclude software.tar -cvf $DEST .
+tar --directory $ROOT --exclude software.tar -cvf \$DEST .
 EOL
 chmod ug+x $ROOT/generate-tar-cache.sh
 

--- a/script/frontier/install.sh
+++ b/script/frontier/install.sh
@@ -16,7 +16,7 @@ ROOT=$(realpath $1)
 echo "Installing glotzerlab-software to $ROOT"
 module purge
 module load PrgEnv-gnu
-module load cray-python/3.9.13.1
+module load cray-python/3.10.10
 python3 -m venv $ROOT
 
 cat >$ROOT/variables.sh << EOL
@@ -25,7 +25,7 @@ module load PrgEnv-gnu
 module load cmake/3.23.2
 module load git/2.36.1
 module load rocm/5.4.3
-module load cray-python/3.9.13.1
+module load cray-python/3.10.10
 module load hdf5/1.14.0
 module load ninja/1.10.2
 module load tmux/3.2a

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -40,6 +40,7 @@ export CPATH=\$GLOTZERLAB_SOFTWARE_ROOT/include
 export LIBRARY_PATH=\$GLOTZERLAB_SOFTWARE_ROOT/lib
 export VIRTUAL_ENV=\$GLOTZERLAB_SOFTWARE_ROOT
 export CMAKE_PREFIX_PATH=\$GLOTZERLAB_SOFTWARE_ROOT
+export PYTHONPATH=\$(\${GLOTZERLAB_SOFTWARE_ROOT}/bin/python -c 'import site; print(site.getsitepackages()[0])')
 export CC=\$GCC_PATH/bin/gcc
 export CXX=\$GCC_PATH/bin/g++
 
@@ -71,7 +72,7 @@ fi
 
 DEST=\$(realpath \$1)
 
-tar --directory $ROOT --exclude software.tar -cvf \$DEST .
+tar --directory $ROOT --exclude software.tar -cf \$DEST .
 EOL
 chmod ug+x $ROOT/generate-tar-cache.sh
 

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -71,7 +71,7 @@ fi
 
 DEST=\$(realpath \$1)
 
-tar --directory $ROOT --exclude software.tar -cvf $DEST .
+tar --directory $ROOT --exclude software.tar -cvf \$DEST .
 EOL
 chmod ug+x $ROOT/generate-tar-cache.sh
 

--- a/template/frontier.jinja
+++ b/template/frontier.jinja
@@ -16,7 +16,7 @@ ROOT=$(realpath $1)
 echo "Installing glotzerlab-software to $ROOT"
 module purge
 module load PrgEnv-gnu
-module load cray-python/3.9.13.1
+module load cray-python/3.10.10
 python3 -m venv $ROOT
 
 cat >$ROOT/variables.sh << EOL
@@ -25,7 +25,7 @@ module load PrgEnv-gnu
 module load cmake/3.23.2
 module load git/2.36.1
 module load rocm/5.4.3
-module load cray-python/3.9.13.1
+module load cray-python/3.10.10
 module load hdf5/1.14.0
 module load ninja/1.10.2
 module load tmux/3.2a


### PR DESCRIPTION
For Frontier:
* Increase PMPI_Init timeout (fails after 180 seconds by default).
* Add scripts and documentation to support Python environments in node-local NVME storage.
* Unrelated: Update to Python 3.10 as it is now available on Frontier.

When launching 64 node jobs with `hoomd-validation` on Frontier, Python takes ~500 seconds to import `flow` and other packages from `/ccs/proj`. This exceeds the `PMPI_Init` timeout and causes jobs to fail with:
```
Wed Oct 11 15:15:14 2023: [PE_1295]:_pmi_mmap_tmp: Warning bootstrap barrier failed: num_syncd=40, pes_this_node=56, timeout=180 secs
Wed Oct 11 15:15:14 2023: [PE_1318]:_pmi_mmap_tmp: Warning bootstrap barrier failed: num_syncd=40, pes_this_node=56, timeout=180 secs
Wed Oct 11 15:15:14 2023: [PE_1318]:_pmi_mmap_init:Failed to setup PMI mmap.Wed Oct 11 15:15:14 2023: [PE_1318]:globals_init:_pmi_mmap_init ret
urned -1
MPICH ERROR [Rank 0] [job id unknown] [Wed Oct 11 15:15:14 2023] [frontier03965] - Abort(1091855) (rank 0 in comm 0): Fatal error in PMPI_Init:
Other MPI error, error stack:
MPIR_Init_thread(170):  MPID_Init(441).......:  MPIR_pmi_init(110)...: PMI_Init returned 1
...
```

Increasing the timeout allows jobs to run, but wastes many minutes importing packages at the start of each job. The new instructions direct the user to store the environment in a tar file on Orion and unpack it to NVME at the start of the job. This reduces the import time in `hoomd-validation` down to ~20 seconds, including the time it takes to unpack the tar file (typically 1-2 seconds).

Using the tar file is optional: `source /ccs/proj/.../environment.sh` continues to function, but without the performance benefit.