### PR TITLE
Remove werkzeug pinning.

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Bump versions in .github/workflows/requirements.txt
         run: pur -r .github/workflows/requirements.txt
       - name: Bump versions in requirements.txt
-        run: pur -r requirements.txt --minor Werkzeug
+        run: pur -r requirements.txt
       - name: Bump versions in requirements-mpi.txt
         run: pur -r requirements-mpi.txt
       - name: Bump versions in requirements-source.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ signac-flow==0.26.1
 signac-dashboard==0.6.0
 
 # transitive dependencies
-Werkzeug==2.3.7
+Werkzeug==3.0.1
+flask-login==0.6.3
+flask==3.0.0
 
 # commonly used packages
 h5py==3.10.0


### PR DESCRIPTION
flask-login 0.6.3 allows the use of the latest werkzeug version.