### PR TITLE
Update greatlakes.rst

### DIFF
--- a/doc/clusters/greatlakes.rst
+++ b/doc/clusters/greatlakes.rst
@@ -18,6 +18,7 @@ directory::
 
 Download the image with support for Great Lakes::
 
+    $ module load singularity
     $ singularity pull software.sif docker://glotzerlab/software:greatlakes
 
 Using


### PR DESCRIPTION
Greatlakes requires the singularity module to be loaded before running `singularity pull`. This change updates the documentation to reflect that.